### PR TITLE
Feature/add pr check

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -7,8 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - closed
+      
   workflow_dispatch:
 
 permissions:
@@ -29,7 +28,8 @@ jobs:
         id: lasttag
         run: |
           git fetch --tags --force
-          last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          last_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)
+          [ -z "$last_tag" ] && last_tag="v0.0.0"
           echo "last_tag=$last_tag" >> $GITHUB_OUTPUT
           echo "Last tag: $last_tag"
 
@@ -91,6 +91,7 @@ jobs:
             exit 0
           fi
           new_tag="v${major}.${minor}.${patch}"
+          major_tag="v${major}" >> $GITHUB_OUTPUT
           echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
           echo "New tag: $new_tag"
 
@@ -104,8 +105,19 @@ jobs:
             echo "Tag $new already exists. Skipping."
             exit 0
           fi
+          
+
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
+          
           git tag -a "$new" -m "chore(release): $new"
+          # Remove major tag if it exists, then create/update it
+          major_tag="${{ steps.version.outputs.major_tag }}"
+          if git rev-parse -q --verify "refs/tags/$major_tag" >/dev/null; then
+            git tag -d "$major_tag"
+            git push origin ":refs/tags/$major_tag"
+          fi
+          git tag -a "$major_tag" -m "chore(release): $major_tag"
+          git push origin "$major_tag"
           git push origin "$new"
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -35837,6 +35837,7 @@ function parseCoverageReport(xml, format = 'auto') {
     const doc = parser.parse(xml);
     const rootName = Object.keys(doc)[0];
     // Simple heuristics by root node
+    // JaCoCo
     if (rootName === 'report' && doc.report?.package) {
         return parseJaCoCo(doc);
     }
@@ -35846,7 +35847,7 @@ function parseCoverageReport(xml, format = 'auto') {
     if (rootName === 'CoverageSession' && doc.CoverageSession?.Summary) {
         return parseOpenCover(doc);
     }
-    // Try some other hints
+    // Try some other hints if root node is not enough
     if (doc?.report?.counter && doc?.report?.package)
         return parseJaCoCo(doc);
     if (doc?.coverage)

--- a/dist/parsers/registry.js
+++ b/dist/parsers/registry.js
@@ -10,6 +10,7 @@ export function parseCoverageReport(xml, format = 'auto') {
     const doc = parser.parse(xml);
     const rootName = Object.keys(doc)[0];
     // Simple heuristics by root node
+    // JaCoCo
     if (rootName === 'report' && doc.report?.package) {
         return parseJaCoCo(doc);
     }
@@ -19,7 +20,7 @@ export function parseCoverageReport(xml, format = 'auto') {
     if (rootName === 'CoverageSession' && doc.CoverageSession?.Summary) {
         return parseOpenCover(doc);
     }
-    // Try some other hints
+    // Try some other hints if root node is not enough
     if (doc?.report?.counter && doc?.report?.package)
         return parseJaCoCo(doc);
     if (doc?.coverage)

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -16,6 +16,7 @@ export function parseCoverageReport(xml: string, format: SupportedFormat = 'auto
   const rootName = Object.keys(doc)[0];
 
   // Simple heuristics by root node
+  // JaCoCo
   if (rootName === 'report' && doc.report?.package) {
     return parseJaCoCo(doc);
   }
@@ -26,7 +27,7 @@ export function parseCoverageReport(xml: string, format: SupportedFormat = 'auto
     return parseOpenCover(doc);
   }
 
-  // Try some other hints
+  // Try some other hints if root node is not enough
   if (doc?.report?.counter && doc?.report?.package) return parseJaCoCo(doc);
   if (doc?.coverage) return parseCobertura(doc);
   if (doc?.CoverageSession) return parseOpenCover(doc);


### PR DESCRIPTION
This pull request makes several improvements to the `auto-tag.yaml` GitHub Actions workflow and clarifies code comments in the coverage report parser. The most significant updates are focused on making the tagging workflow more robust and ensuring major version tags are managed correctly. Additionally, the code comments in the coverage parser have been clarified for better maintainability.

**GitHub Actions Workflow Improvements:**

* The workflow now triggers on all pull request events to `main`, not just when PRs are closed, ensuring tags are updated more reliably.
* The logic for determining the last tag has been improved to sort tags semantically and default to `v0.0.0` if none are found.
* The workflow now creates or updates a major version tag (e.g., `v1`) with each release, deleting and recreating it as needed to always point to the latest release in that major version. [[1]](diffhunk://#diff-170943784adfecf8e8946f3ce609efd88fe3eeb854ff7aa7b051db9b49bbe0feR94) [[2]](diffhunk://#diff-170943784adfecf8e8946f3ce609efd88fe3eeb854ff7aa7b051db9b49bbe0feR108-R121)

**Code Comment Clarifications:**

* Added and clarified comments in `src/parsers/registry.ts` to explain the logic for detecting and parsing different coverage report formats. [[1]](diffhunk://#diff-a0fe8a3b811e0570dccb9993280248a953a75788cb23361e050021c2effbe4a8R19) [[2]](diffhunk://#diff-a0fe8a3b811e0570dccb9993280248a953a75788cb23361e050021c2effbe4a8L29-R30)