### PR TITLE
Feature/add pr check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,18 +40,13 @@ jobs:
           git config user.email "$USER_CONFIG_ID"
 
           # Força a atualização da pasta dist uma vez que ela é ignorada no .gitignore
-          git add -f dist/      
+          git add -f dist/
 
-          # Adicione uma verificação para garantir que há mudanças a serem commitadas
-          if [[ -n $(git status --porcelain) ]]; then
+          # Verifica se há mudanças STAGED (no dist) para commitar
+          if git diff --cached --quiet; then
+            echo "ℹ️ No build output changes in dist to commit. Skipping commit."
+            exit 0
+          else
             git commit -m "Executing build ${{ github.head_ref || github.ref_name }}"
             git push origin ${{ github.head_ref || github.ref_name }}
-          else
-            echo "⚠️ We don't find changes to commit for ${{ github.head_ref || github.ref_name }}."
-            echo "⚡ Please make changes to the code on the branch before publishing."
-            echo ""
-            echo "   - If you need help, feel free to ask!"
-            echo "   - You can also check the documentation for more information."
-            echo "   - Make sure your branch is up to date with the base branch."
-            exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 
 GitHub Action para validar a cobertura de código a partir de relatórios XML de múltiplos formatos (JaCoCo, Cobertura, OpenCover, etc).
 
-## Usage
+> [!IMPORTANT]
+> Essa Actinon não gera o coverage de cobertura de codigo, ela é especifica para ler o relatorio em xml, e barrar o workflow se não atingir o valor definido!
 
+## Usage
 
 
 ## Como usar (GitHub Actions)


### PR DESCRIPTION
This pull request introduces a minor clarification to the documentation and improves the commit logic in the CI workflow. The main changes are a clearer explanation in the `README.md` about the action's purpose and a more robust check for staged changes in the build output before committing.

**Workflow improvements:**

* Updated the CI workflow in `.github/workflows/ci.yaml` to check for staged changes in the `dist/` directory using `git diff --cached --quiet`. Now, if there are no staged build output changes, the workflow skips the commit and exits gracefully, reducing unnecessary error messages.

**Documentation updates:**

* Added a prominent note to `README.md` clarifying that the action does not generate coverage reports, but only reads existing XML reports and enforces thresholds.